### PR TITLE
Remove misleading error log

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -149,7 +149,6 @@ impl<C: Connector> EppClient<C> {
             tr_ids: rsp.tr_ids,
         }));
 
-        error!(%response, "Failed to deserialize response for transaction: {}", err);
         Err(err)
     }
 


### PR DESCRIPTION
At this point, the serialization was successful, but rather the command status is not a success as per`fn is_success fn`.
Removing this error log in favor of logging at the call-side.
This allows to handle the response status gracefully without emitting error logs.