### PR TITLE
Use rustls-native-certs as the root store

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,6 +34,10 @@ jobs:
         with:
           command: test
           args: --all-features
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-default-features
 
   lint:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,8 @@ description = "EPP client library for async Rust"
 repository = "https://github.com/InstantDomain/instant-epp"
 
 [features]
-default = ["tokio-rustls"]
+default = ["rustls"]
+rustls = ["tokio-rustls"]
 
 [dependencies]
 async-trait = "0.1.52"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,18 +9,18 @@ repository = "https://github.com/InstantDomain/instant-epp"
 
 [features]
 default = ["rustls"]
-rustls = ["tokio-rustls"]
+rustls = ["tokio-rustls", "rustls-native-certs"]
 
 [dependencies]
 async-trait = "0.1.52"
 celes = "2.1"
 chrono = { version = "0.4.23", features = ["serde"] }
 instant-xml = { version = "0.3", features = ["chrono"] }
+rustls-native-certs = { version = "0.6.3", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1.0", features = ["io-util", "net", "time"] }
 tokio-rustls = { version = "0.24", optional = true }
 tracing = "0.1.29"
-webpki-roots = "0.24"
 
 [dev-dependencies]
 regex = "1.5"

--- a/src/client.rs
+++ b/src/client.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use tracing::{debug, error};
 
 use crate::common::NoExtension;
-#[cfg(feature = "tokio-rustls")]
+#[cfg(feature = "rustls")]
 use crate::common::{Certificate, PrivateKey};
 pub use crate::connection::Connector;
 use crate::connection::EppConnection;
@@ -29,7 +29,7 @@ use crate::xml;
 /// use instant_epp::domain::DomainCheck;
 /// use instant_epp::common::NoExtension;
 ///
-/// # #[cfg(feature = "tokio-rustls")]
+/// # #[cfg(feature = "rustls")]
 /// # #[tokio::main]
 /// # async fn main() {
 /// // Create an instance of EppClient
@@ -54,7 +54,7 @@ use crate::xml;
 ///     .for_each(|chk| println!("Domain: {}, Available: {}", chk.inner.id, chk.inner.available));
 /// # }
 /// #
-/// # #[cfg(not(feature = "tokio-rustls"))]
+/// # #[cfg(not(feature = "rustls"))]
 /// # fn main() {}
 /// ```
 ///
@@ -68,7 +68,7 @@ pub struct EppClient<C: Connector> {
     connection: EppConnection<C>,
 }
 
-#[cfg(feature = "tokio-rustls")]
+#[cfg(feature = "rustls")]
 impl EppClient<RustlsConnector> {
     /// Connect to the specified `addr` and `hostname` over TLS
     ///
@@ -208,10 +208,10 @@ impl<'c, 'e, C, E> Clone for RequestData<'c, 'e, C, E> {
 // Manual impl because this does not depend on whether `C` and `E` are `Copy`
 impl<'c, 'e, C, E> Copy for RequestData<'c, 'e, C, E> {}
 
-#[cfg(feature = "tokio-rustls")]
+#[cfg(feature = "rustls")]
 use rustls_connector::RustlsConnector;
 
-#[cfg(feature = "tokio-rustls")]
+#[cfg(feature = "rustls")]
 mod rustls_connector {
     use std::io;
     use std::sync::Arc;


### PR DESCRIPTION
This is more in line with how we're using other crates.