### PR TITLE
Upgrade tokio-rustls to 0.26

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "instant-epp"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 rust-version = "1.63"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ rustls-native-certs = { version = "0.7", optional = true }
 rustls-pki-types = { version = "1", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1.0", features = ["io-util", "net", "time"] }
-tokio-rustls = { version = "0.25", optional = true }
+tokio-rustls = { version = "0.26", optional = true, default-features = false, features = ["logging", "ring", "tls12"] }
 tracing = "0.1.29"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 rust-version = "1.63"
 license = "MIT"
 description = "EPP client library for async Rust"
-repository = "https://github.com/InstantDomain/instant-epp"
+repository = "https://github.com/instant-labs/instant-epp"
 
 [features]
 default = ["rustls"]


### PR DESCRIPTION
I don't think this causes any semver-incompatible changes?