### PR TITLE
Bump version to 0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "instant-epp"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 rust-version = "1.63"
 license = "MIT"


### PR DESCRIPTION
This takes an incompatible public dependency (instant-xml), so I guess it needs an incompatible bump, too.